### PR TITLE
chore: update publish action

### DIFF
--- a/.changeset/nice-bears-peel.md
+++ b/.changeset/nice-bears-peel.md
@@ -1,0 +1,5 @@
+---
+"@timberland/web-controllers": patch
+---
+
+Testing again ... definitely the problem was that we were pushing directly to main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,8 @@ jobs:
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
-        # uncomment this when we have a build step
-        # with:
-        #   publish: pnpm run build
+        with:
+          publish: pnpm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
ok so the issue was that we were pushing changeset directly to main, so it was triggering the whole workflow